### PR TITLE
Ensure test isolation via repository reset hooks

### DIFF
--- a/src/__tests__/likes.spec.js
+++ b/src/__tests__/likes.spec.js
@@ -2,6 +2,9 @@ const request = require("supertest");
 const app = require("../app");
 
 describe("Likes", () => {
+  beforeEach(() => {
+    app.resetRepositories();
+  });
   it("should be able to give a like to the repository", async () => {
     const repository = await request(app)
       .post("/repositories")

--- a/src/__tests__/repositories.spec.js
+++ b/src/__tests__/repositories.spec.js
@@ -3,6 +3,9 @@ const app = require("../app");
 const { isUuid } = require("uuidv4");
 
 describe("Repositories", () => {
+  beforeEach(() => {
+    app.resetRepositories();
+  });
   it("should be able to create a new repository", async () => {
     const response = await request(app)
       .post("/repositories")

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,10 @@ app.use(cors());
 
 const repositories = [];
 
+function resetRepositories() {
+  repositories.length = 0;
+}
+
 app.get("/repositories", (request, response) => {
   return response.json(repositories);
 });
@@ -86,3 +90,5 @@ app.post("/repositories/:id/like", (request, response) => {
 });
 
 module.exports = app;
+module.exports.repositories = repositories;
+module.exports.resetRepositories = resetRepositories;


### PR DESCRIPTION
## Summary
- add function to reset repository list
- expose internal storage helpers from the app
- clear stored repositories before each test run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445f21abb48320b6ac1852ce277dba