### PR TITLE
Fix delete route 204 response

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -67,7 +67,7 @@ app.delete("/repositories/:id", (request, response) => {
 
   repositories.splice(repositoryIndex, 1);
 
-  return response.status(204).json();
+  return response.status(204).send();
 });
 
 app.post("/repositories/:id/like", (request, response) => {


### PR DESCRIPTION
## Summary
- ensure delete route sends empty 204 response

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68445f1fd1408320b6b177a2300617ed